### PR TITLE
Update generate_sdk.sh script to pass sysroot tar.gz file on the command line. 

### DIFF
--- a/generate_sdk.sh
+++ b/generate_sdk.sh
@@ -2,19 +2,21 @@
 
 set -e
 
-SYSROOT_DOWNLOAD_PATH="https://storage.googleapis.com/axon-artifacts/sysroot-stretch-9.1-20180104-2.tar.gz"
 BINUTILS_DOWNLOAD_PATH="https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2"
-usage="$(basename "$0") [-h] -s <directory_of_sdk> -- This script generates the SDK directory for Raspberry Pi that can be used to compile C/C++ programs using clang.
+usage="$(basename "$0") [-h] -r <sysroot tar file path> -s <directory_of_sdk> -- This script generates the SDK directory for Raspberry Pi that can be used to compile C/C++ programs using clang.
 
 where:
     -h  show this help text
+    -r  Local path to the sysroot tar.gz file from a Raspbian box
     -s  The directory where the SDK should be generated"
 
 sdk_output_dir=""
-while getopts ':hs:' option; do
+while getopts ':hr:s:' option; do
   case "$option" in
     h) echo "$usage"
        exit
+       ;;
+    r) sysroot_path=$OPTARG
        ;;
     s) sdk_output_dir=$OPTARG
        ;;
@@ -82,7 +84,8 @@ rm -rf ${tmpdir}
 
 # Sysroot from RPI
 pushd ${sdk_sysroot_output_dir}
-curl ${SYSROOT_DOWNLOAD_PATH} | tar -xz
+echo "Expanding ${sysroot_path} into sysroot directory ${sdk_sysroot_output_dir}"
+tar -xzf ${sysroot_path}
 popd
 
 #TODO(zasgar): Figure out why this is needed? Probably something to do with LD compile options.


### PR DESCRIPTION
This changeset makes it so the user needs to pass the generate_sdk.sh a local path to the raspberry pi sysroot tar.gz file that is generated using the instructions at https://medium.com/@zw3rk/making-a-raspbian-cross-compilation-sdk-830fe56d75ba and then tarred and compressed to a file. It fixes Issue #1 by allowing the user to specify their own sysroot file.  In addition, it also allows the script to support either stretch or jessie since that depends on the sysroot files.